### PR TITLE
Window not visible if previously shut down as minimized

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -93,6 +93,8 @@ main() async {
       double? windowPositionX = sharedPrefsService!.get(kWindowPositionXKey);
       double? windowPositionY = sharedPrefsService!.get(kWindowPositionYKey);
       if (windowPositionX != null && windowPositionY != null) {
+        windowPositionX = windowPositionX >= 0 ? windowPositionX : 100;
+        windowPositionY = windowPositionY >= 0 ? windowPositionY : 100;
         await windowManager
             .setPosition(Offset(windowPositionX, windowPositionY));
       }


### PR DESCRIPTION
Closes #2 

This fixes the issue of the application window not being visible.
The fix verifies that the stored window position is in the visible area of the screen at start up.