### PR TITLE
Fix Get-It dispose

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -303,6 +303,7 @@ class _MyAppState extends State<MyApp> with WindowListener {
     sl<Zenon>().wsClient.stop();
     Future.delayed(const Duration(seconds: 60)).then((value) => exit(0));
     await NodeUtils.closeEmbeddedNode();
+    await sl.reset();
     super.onWindowClose();
     deactivate();
     dispose();
@@ -311,8 +312,7 @@ class _MyAppState extends State<MyApp> with WindowListener {
 
   @override
   void dispose() {
-    windowManager.removeListener(this);
-    sl.unregister();
+    windowManager.removeListener(this);    
     super.dispose();
   }
 }


### PR DESCRIPTION
# What?

Calling the Get-It Service Locator unregister method within the main dispose method causes an exception when closing the application.

# Why?

According to the [Get-It](https://pub.dev/packages/get_it) package documentation the unregister method is used to unregister an [instance] of an object or a factory/singleton by Type [T] or by name [instanceName]. Not supplying an Type [T] or name causes the exception.

The `reset` method should be used to fully dispose the Service Locator. The `reset` method is asynchronous and cannot be used in the dispose method.

# How?

Call the `reset` method of the Get-It Service Locator in the asynchronous `onWindowClose` method.