### PR TITLE
Fix fusing address reset

### DIFF
--- a/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
+++ b/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
@@ -56,6 +56,8 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
   final GlobalKey<FormState> _beneficiaryAddressKey = GlobalKey();
   final GlobalKey<LoadingButtonState> _fuseButtonKey = GlobalKey();
 
+  PlasmaBeneficiaryAddressNotifier? _plasmaBeneficiaryAddress;
+
   int? _maxQsrAmount;
   double? _maxWidth;
 
@@ -68,6 +70,10 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
 
   @override
   void initState() {
+    _plasmaBeneficiaryAddress =
+        Provider.of<PlasmaBeneficiaryAddressNotifier>(context, listen: false);
+    _plasmaBeneficiaryAddress!.addListener(_beneficiaryAddressListener);
+
     super.initState();
     sl.get<BalanceBloc>().getBalanceForAllAddresses();
   }
@@ -132,112 +138,110 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
     );
   }
 
+  void _beneficiaryAddressListener() {
+    _beneficiaryAddressController.text =
+        _plasmaBeneficiaryAddress!.getBeneficiaryAddress()!;
+  }
+
   Widget _getWidgetBody(AccountInfo? accountInfo) {
-    return Consumer<PlasmaBeneficiaryAddressNotifier>(
-      builder: (_, notifier, child) {
-        _beneficiaryAddressController.text = notifier.getBeneficiaryAddress()!;
-        return Container(
-          margin: EdgeInsets.all(_marginWidth),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                flex: _beneficiaryAddressExpandedFlex,
-                child: ListView(
-                  shrinkWrap: true,
-                  children: [
-                    DisabledAddressField(
-                      _addressController,
+    return Container(
+      margin: EdgeInsets.all(_marginWidth),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            flex: _beneficiaryAddressExpandedFlex,
+            child: ListView(
+              shrinkWrap: true,
+              children: [
+                DisabledAddressField(
+                  _addressController,
+                  contentLeftPadding: 20.0,
+                ),
+                StepperUtils.getBalanceWidget(kQsrCoin, accountInfo!),
+                Form(
+                  key: _beneficiaryAddressKey,
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  child: InputField(
+                    onChanged: (String value) {
+                      _beneficiaryAddressString.value = value;
+                    },
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(RegExp(r'[0-9a-z]')),
+                    ],
+                    controller: _beneficiaryAddressController,
+                    hintText: 'Beneficiary address',
+                    contentLeftPadding: 20.0,
+                    validator: (value) => InputValidators.checkAddress(value),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: _spaceBetweenExpandedWidgets,
+          ),
+          Expanded(
+            flex: _fuseButtonExpandedFlex,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SizedBox(
+                  height: 87.0,
+                  child: Form(
+                    key: _qsrAmountKey,
+                    autovalidateMode: AutovalidateMode.onUserInteraction,
+                    child: InputField(
+                      enabled: _maxQsrAmount! > 0,
+                      onChanged: (String value) {
+                        setState(() {});
+                      },
+                      inputFormatters:
+                          FormatUtils.getPlasmaAmountTextInputFormatters(
+                        _qsrAmountController.text,
+                      ),
+                      controller: _qsrAmountController,
+                      validator: (value) => InputValidators.correctValue(
+                        value,
+                        _maxQsrAmount,
+                        kQsrCoin.decimals,
+                        min: fuseMinQsrAmount.addDecimals(
+                          qsrDecimals,
+                        ),
+                        canBeEqualToMin: true,
+                      ),
+                      suffixIcon: _getAmountSuffix(),
+                      hintText: 'Amount',
                       contentLeftPadding: 20.0,
                     ),
-                    StepperUtils.getBalanceWidget(kQsrCoin, accountInfo!),
-                    Form(
-                      key: _beneficiaryAddressKey,
-                      autovalidateMode: AutovalidateMode.onUserInteraction,
-                      child: InputField(
-                        onChanged: (String value) {
-                          _beneficiaryAddressString.value = value;
-                        },
-                        inputFormatters: [
-                          FilteringTextInputFormatter.allow(
-                              RegExp(r'[0-9a-z]')),
-                        ],
-                        controller: _beneficiaryAddressController,
-                        hintText: 'Beneficiary address',
-                        contentLeftPadding: 20.0,
-                        validator: (value) =>
-                            InputValidators.checkAddress(value),
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
-              ),
-              SizedBox(
-                width: _spaceBetweenExpandedWidgets,
-              ),
-              Expanded(
-                flex: _fuseButtonExpandedFlex,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    SizedBox(
-                      height: 87.0,
-                      child: Form(
-                        key: _qsrAmountKey,
-                        autovalidateMode: AutovalidateMode.onUserInteraction,
-                        child: InputField(
-                          enabled: _maxQsrAmount! > 0,
-                          onChanged: (String value) {
-                            setState(() {});
-                          },
-                          inputFormatters:
-                              FormatUtils.getPlasmaAmountTextInputFormatters(
-                            _qsrAmountController.text,
-                          ),
-                          controller: _qsrAmountController,
-                          validator: (value) => InputValidators.correctValue(
-                            value,
-                            _maxQsrAmount,
-                            kQsrCoin.decimals,
-                            min: fuseMinQsrAmount.addDecimals(
-                              qsrDecimals,
-                            ),
-                            canBeEqualToMin: true,
-                          ),
-                          suffixIcon: _getAmountSuffix(),
-                          hintText: 'Amount',
-                          contentLeftPadding: 20.0,
-                        ),
-                      ),
-                    ),
-                    ValueListenableBuilder<String>(
-                      valueListenable: _beneficiaryAddressString,
-                      builder: (_, __, ___) {
-                        return Row(
-                          children: [
-                            _getGeneratePlasmaButtonStreamBuilder(),
-                            Visibility(
-                              visible: _isInputValid(),
-                              child: Row(
-                                children: [
-                                  const SizedBox(
-                                    width: 10.0,
-                                  ),
-                                  _getPlasmaIcon(),
-                                ],
+                ValueListenableBuilder<String>(
+                  valueListenable: _beneficiaryAddressString,
+                  builder: (_, __, ___) {
+                    return Row(
+                      children: [
+                        _getGeneratePlasmaButtonStreamBuilder(),
+                        Visibility(
+                          visible: _isInputValid(),
+                          child: Row(
+                            children: [
+                              const SizedBox(
+                                width: 10.0,
                               ),
-                            )
-                          ],
-                        );
-                      },
-                    ),
-                  ],
+                              _getPlasmaIcon(),
+                            ],
+                          ),
+                        )
+                      ],
+                    );
+                  },
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-        );
-      },
+        ],
+      ),
     );
   }
 
@@ -378,6 +382,7 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
 
   @override
   void dispose() {
+    _plasmaBeneficiaryAddress!.removeListener(_beneficiaryAddressListener);
     _qsrAmountController.dispose();
     _addressController.dispose();
     _beneficiaryAddressController.dispose();


### PR DESCRIPTION
# What?

Under the plasma tab, where if you enter the beneficiary address, entering the amount resets the beneficiary address to the current selected address, and you need to change it again.

# Why?

A widget’s state is stored in a [`State`](https://api.flutter.dev/flutter/widgets/State-class.html) object, separating the widget’s state from its appearance. The state consists of values that can change, like a slider’s current value or whether a checkbox is checked. When the widget’s state changes, the state object calls `setState()`, telling the framework to redraw the widget.

The `setState()` is called when the amount changes, causing a redraw of the widget.

The beneficiary address is initialized in the build method. A redraw will initialize and consequently overwrite the beneficiary address to the currently selected address. Effectivly overwriting changes made to beneficiary address everytime the amount changes.

# How?

By subscribing to the `PlasmaBeneficiaryAddressNotifier` in the `initState` method, will initializes the beneficiary address one time and overwrite it when the selected address changes and not when the widget gets rebuild.

# Anything else?

Using Provider.of<>() within the `initState` method requires listen to be false.

The `PlasmaBeneficiaryAddressNotifier` ends up with multiple listeners when using an anonymous method which could introduce a memory leak.