### PR TITLE
Fix AZ listing and filtering

### DIFF
--- a/lib/blocs/accelerator/project_list_bloc.dart
+++ b/lib/blocs/accelerator/project_list_bloc.dart
@@ -105,39 +105,26 @@ class ProjectListBloc with RefreshBlocMixin {
     _onPageRequest.close();
   }
 
-  Future<List<Project>> _getDataBySearchTerm(
-    int pageKey,
-    int pageSize,
-    String searchTerm,
-  ) async {
-    _allProjects ??= (await zenon!.embedded.accelerator.getAll()).list;
-    Set<Project> results =
-        _filterProjectsBySearchKeyWord(_allProjects!, searchTerm);
-    List<Project> subListResults = results.toList().sublist(
-          pageKey * pageSize,
-          (pageKey + 1) * pageSize <= results.length
-              ? (pageKey + 1) * pageSize
-              : results.length,
-        );
-    return _filterProjectsAccordingToPillarInfo(
-        await _filterProjectsByTags(subListResults));
-  }
-
   Future<List<Project>> getData(
     int pageKey,
     int pageSize,
     String? searchTerm,
   ) async {
+    _allProjects ??= (await zenon!.embedded.accelerator.getAll()).list;
+    List<Project> results = [];
     if (searchTerm != null && searchTerm.isNotEmpty) {
-      return _getDataBySearchTerm(pageKey, pageSize, searchTerm);
+      results =
+          _filterProjectsBySearchKeyWord(_allProjects!, searchTerm).toList();
+    } else {
+      results = _allProjects!;
     }
-    List<Project> projectList = (await zenon!.embedded.accelerator.getAll(
-      pageIndex: pageKey,
-      pageSize: pageSize,
-    ))
-        .list;
-    return await _filterProjectsAccordingToPillarInfo(
-      await _filterProjectsByTags(projectList),
+    results = (await _filterProjectsAccordingToPillarInfo(
+        await _filterProjectsByTags(results)));
+    return results.sublist(
+      pageKey * pageSize,
+      (pageKey + 1) * pageSize <= results.length
+          ? (pageKey + 1) * pageSize
+          : results.length,
     );
   }
 
@@ -221,38 +208,27 @@ class ProjectListBloc with RefreshBlocMixin {
   Future<Set<Project>> _filterProjectsByTags(List<Project> projects) async {
     if (selectedProjectsFilterTag.isNotEmpty) {
       Iterable<Hash>? votedProjectIds;
-      var filteredProjects = const Iterable<Project>.empty();
+      Iterable<Project> filteredProjects = projects;
       if (selectedProjectsFilterTag.contains(ProjectsFilterTag.myProjects)) {
-        filteredProjects = projects.where(
+        filteredProjects = filteredProjects.where(
           (project) => kDefaultAddressList.contains(project.owner.toString()),
         );
       }
       if (selectedProjectsFilterTag.contains(ProjectsFilterTag.onlyAccepted)) {
-        if (filteredProjects.isNotEmpty) {
-          filteredProjects = filteredProjects.where(
-              (project) => project.status == AcceleratorProjectStatus.active);
-        } else {
-          filteredProjects = projects.where(
-              (project) => project.status == AcceleratorProjectStatus.active);
-        }
+        filteredProjects = filteredProjects.where(
+            (project) => project.status == AcceleratorProjectStatus.active);
       }
       if (selectedProjectsFilterTag.contains(ProjectsFilterTag.votingOpened)) {
-        var projectsToBeChecked =
-            filteredProjects.isNotEmpty ? filteredProjects : projects;
-        votedProjectIds ??=
-            await _getVotedProjectIdsByPillar(projectsToBeChecked);
-        filteredProjects = projectsToBeChecked.where(
+        votedProjectIds ??= await _getVotedProjectIdsByPillar(filteredProjects);
+        filteredProjects = filteredProjects.where(
           (project) =>
               project.status == AcceleratorProjectStatus.voting &&
               !votedProjectIds!.contains(project.id),
         );
       }
       if (selectedProjectsFilterTag.contains(ProjectsFilterTag.alreadyVoted)) {
-        var projectsToBeChecked =
-            filteredProjects.isNotEmpty ? filteredProjects : projects;
-        votedProjectIds ??=
-            await _getVotedProjectIdsByPillar(projectsToBeChecked);
-        filteredProjects = projectsToBeChecked.where(
+        votedProjectIds ??= await _getVotedProjectIdsByPillar(filteredProjects);
+        filteredProjects = filteredProjects.where(
           (project) => votedProjectIds!.contains(project.id),
         );
       }


### PR DESCRIPTION
# What?

Incomplete results are given when filtering Accelerator Z projects without using a search term.

# Why?

The bug only occures when no search term is used.

When no search term is used, the `getAll(pageIndex, pageSize)` paging method is used. The paging variables are supplied by the `infinite_scroll_bloc`.

The `infinite_scroll_bloc` uses a static `pageSize` of 10.

Example: the `getAll()` method returns 10 projects, 6 of which are rejected or completed. The user applies the "Only Accepted" filter and filters the initial 10 results down to 4.

The `infinite_scroll_bloc` checks if it has reached the last page with the following check.

`final isLastPage = newItems.length < _pageSize;`

Because the result was filtered down to 4, the `infinite_scroll_bloc` thinks it has now reached the end and shows no more results. This causes other accepted projects to be dropped.

In general a paging method cannot be used if filtering is applied at a later stage.

# How?

Paging must be applied after filtering by using the `getAll()` non-paging method and apply paging after the search term, tag and pillar filtering.

# Anything else?

1. A filter tag is not applied when the result is empty. This causes strange behaviour.
For example, a non pillar user with no projects. Selecting "My Projects" has no result. Selecting "My Projects" and "Only Accepted" has results. All tag filters should be inclusive.