### PR TITLE
Corrected pillar registration step

### DIFF
--- a/lib/widgets/modular_widgets/pillars_widgets/pillars_stepper_container.dart
+++ b/lib/widgets/modular_widgets/pillars_widgets/pillars_stepper_container.dart
@@ -1035,7 +1035,7 @@ class _MainPillarsState extends State<PillarsStepperContainer> {
 
   void _onQsrNextPressed() {
     setState(() {
-      _currentStep = PillarsStepperStep.values[_currentStep.index + 1];
+      _saveProgressAndNavigateToNextStep(PillarsStepperStep.qsrManagement);
     });
   }
 


### PR DESCRIPTION
**Summary**
Users are unable to register a pillar using Syrius v0.0.6.
After depositing QSR, they reach the ZNN management step but the Next button does not allow them to proceed.

**Bug report**
https://github.com/hypercore-one/syrius/issues/2