### PR TITLE
Reword `Send Payment` to `Send`.

### DIFF
--- a/lib/services/wallet_connect_service.dart
+++ b/lib/services/wallet_connect_service.dart
@@ -328,7 +328,7 @@ class WalletConnectService {
             final wasActionAccepted = await showDialogWithNoAndYesOptions(
               context: _context,
               isBarrierDismissible: false,
-              title: '${dAppMetadata.name} - Send Payment',
+              title: '${dAppMetadata.name} - Send',
               content: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/widgets/modular_widgets/transfer_widgets/send/send_large.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/send/send_large.dart
@@ -226,7 +226,7 @@ class _SendLargeCardState extends State<SendLargeCard> {
       showDialogWithNoAndYesOptions(
         isBarrierDismissible: false,
         context: context,
-        title: 'Send Payment',
+        title: 'Send',
         description: 'Are you sure you want to transfer '
             '${_amountController.text} ${_selectedToken.symbol} to '
             '${ZenonAddressUtils.getLabel(_recipientController.text)} ?',

--- a/lib/widgets/modular_widgets/transfer_widgets/send/send_medium.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/send/send_medium.dart
@@ -180,7 +180,7 @@ class _SendMediumCardState extends State<SendMediumCard> {
       showDialogWithNoAndYesOptions(
         context: context,
         isBarrierDismissible: true,
-        title: 'Send Payment',
+        title: 'Send',
         description: 'Are you sure you want to transfer '
             '${_amountController.text} ${_selectedToken.symbol} to '
             '${ZenonAddressUtils.getLabel(_recipientController.text)} ?',

--- a/lib/widgets/reusable_widgets/buttons/send_payment_button.dart
+++ b/lib/widgets/reusable_widgets/buttons/send_payment_button.dart
@@ -6,9 +6,9 @@ class SendPaymentButton extends LoadingButton {
   const SendPaymentButton({
     required VoidCallback? onPressed,
     required Key key,
-    String text = 'Send payment',
+    String text = 'Send',
     Color? outlineColor,
-    Size minimumSize = const Size(150.0, 40.0),
+    Size minimumSize = const Size(100.0, 40.0),
   }) : super(
           onPressed: onPressed,
           text: text,


### PR DESCRIPTION
This PR implements issue #29 

All occurrences of `"Send Payment"` have been renamed to `"Send"`.