### PR TITLE
Fix FormatException when trying to fuse a large amount

### DIFF
--- a/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
+++ b/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
@@ -132,7 +132,7 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
     _beneficiaryAddressController.text =
         _plasmaBeneficiaryAddress!.getBeneficiaryAddress()!;
     // Notify internal state has changed.
-    setState(() { });
+    setState(() {});
   }
 
   Widget _getWidgetBody(AccountInfo? accountInfo) {
@@ -240,11 +240,13 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
       PlasmaInfo.fromJson(
         {
           'currentPlasma': ((_qsrAmountController.text.isNotEmpty
-                  ? int.parse((zenon!.embedded.plasma.getPlasmaByQsr(
-                      _qsrAmountController.text.extractDecimals(coinDecimals),
-                    )).addDecimals(coinDecimals))
-                  : 0) +
-              _getPlasmaForCurrentBeneficiary()),
+                      ? BigInt.parse(zenon!.embedded.plasma
+                          .getPlasmaByQsr(_qsrAmountController.text
+                              .extractDecimals(coinDecimals))
+                          .addDecimals(coinDecimals))
+                      : BigInt.zero) +
+                  BigInt.from(_getPlasmaForCurrentBeneficiary()))
+              .toInt(),
           'maxPlasma': 0,
           'qsrAmount': '0',
         },


### PR DESCRIPTION
This PR fixes issue #57

The entered QSR amount is used to statically calculate the current plasma for displaying the low/medium/high plasma icon. However when entering a large amount, the `int.parse()` function causes an exception when parsing the calculated result.

The calculation has been changed to use the `BigInt.toInt()` function on the result.