### PR TITLE
Fix receive amount formatting and QrInputTooLongException

### DIFF
--- a/lib/widgets/modular_widgets/transfer_widgets/receive/receive_large.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/receive/receive_large.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
@@ -121,7 +122,12 @@ class _ReceiveLargeCardState extends State<ReceiveLargeCard> {
                               autovalidateMode:
                                   AutovalidateMode.onUserInteraction,
                               child: InputField(
-                                validator: InputValidators.validateAmount,
+                                validator: (value) =>
+                                    InputValidators.correctValue(
+                                        value,
+                                        kBigP255m1,
+                                        _selectedToken.decimals,
+                                        BigInt.zero),
                                 onChanged: (value) => setState(() {}),
                                 inputFormatters:
                                     FormatUtils.getAmountTextInputFormatters(

--- a/lib/widgets/modular_widgets/transfer_widgets/receive/receive_large.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/receive/receive_large.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
-import 'package:lottie/lottie.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/blocs.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/constants.dart';
@@ -27,7 +26,6 @@ class ReceiveLargeCard extends StatefulWidget {
 }
 
 class _ReceiveLargeCardState extends State<ReceiveLargeCard> {
-  final int _maxQrCodeInputLength = 122;
   final TextEditingController _transferAddressController =
       TextEditingController();
   final TextEditingController _amountController = TextEditingController();
@@ -100,43 +98,12 @@ class _ReceiveLargeCardState extends State<ReceiveLargeCard> {
                 const SizedBox(
                   width: 20.0,
                 ),
-                _getQrString().length <= _maxQrCodeInputLength
-                    ? ReceiveQrImage(
-                        data: _getQrString(),
-                        size: 150.0,
-                        tokenStandard: _selectedToken.tokenStandard,
-                        context: context,
-                      )
-                    : Container(
-                        width: 170.0,
-                        height: 170.0,
-                        decoration: const BoxDecoration(
-                          color: AppColors.backgroundDark,
-                          borderRadius: BorderRadius.all(
-                            Radius.circular(15.0),
-                          ),
-                        ),
-                        child: Center(
-                          child: Padding(
-                            padding: const EdgeInsets.all(5.0),
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Lottie.asset(
-                                  'assets/lottie/ic_anim_no_data.json',
-                                  width: 32.0,
-                                  height: 32.0,
-                                ),
-                                Text(
-                                  'Input is too long for QR code',
-                                  textAlign: TextAlign.center,
-                                  style: Theme.of(context).textTheme.bodyMedium,
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
+                ReceiveQrImage(
+                  data: _getQrString(),
+                  size: 150,
+                  tokenStandard: _selectedToken.tokenStandard,
+                  context: context,
+                ),
                 const SizedBox(
                   width: 20.0,
                 ),

--- a/lib/widgets/modular_widgets/transfer_widgets/receive/receive_large.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/receive/receive_large.dart
@@ -1,7 +1,6 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
+import 'package:lottie/lottie.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/blocs.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/constants.dart';
@@ -28,6 +27,7 @@ class ReceiveLargeCard extends StatefulWidget {
 }
 
 class _ReceiveLargeCardState extends State<ReceiveLargeCard> {
+  final int _maxQrCodeInputLength = 122;
   final TextEditingController _transferAddressController =
       TextEditingController();
   final TextEditingController _amountController = TextEditingController();
@@ -100,12 +100,43 @@ class _ReceiveLargeCardState extends State<ReceiveLargeCard> {
                 const SizedBox(
                   width: 20.0,
                 ),
-                ReceiveQrImage(
-                  data: _getQrString(),
-                  size: 150.0,
-                  tokenStandard: _selectedToken.tokenStandard,
-                  context: context,
-                ),
+                _getQrString().length <= _maxQrCodeInputLength
+                    ? ReceiveQrImage(
+                        data: _getQrString(),
+                        size: 150.0,
+                        tokenStandard: _selectedToken.tokenStandard,
+                        context: context,
+                      )
+                    : Container(
+                        width: 170.0,
+                        height: 170.0,
+                        decoration: const BoxDecoration(
+                          color: AppColors.backgroundDark,
+                          borderRadius: BorderRadius.all(
+                            Radius.circular(15.0),
+                          ),
+                        ),
+                        child: Center(
+                          child: Padding(
+                            padding: const EdgeInsets.all(5.0),
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Lottie.asset(
+                                  'assets/lottie/ic_anim_no_data.json',
+                                  width: 32.0,
+                                  height: 32.0,
+                                ),
+                                Text(
+                                  'Input is too long for QR code',
+                                  textAlign: TextAlign.center,
+                                  style: Theme.of(context).textTheme.bodyMedium,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
                 const SizedBox(
                   width: 20.0,
                 ),
@@ -187,10 +218,9 @@ class _ReceiveLargeCardState extends State<ReceiveLargeCard> {
   }
 
   String _getQrString() {
-    var qrData = '${_selectedToken.symbol.toLowerCase()}:'
+    return '${_selectedToken.symbol.toLowerCase()}:'
         '$_selectedSelfAddress?zts=${_selectedToken.tokenStandard}'
         '&amount=${_getAmount()}';
-    return qrData.substring(0, min(qrData.length, 122));
   }
 
   BigInt _getAmount() {

--- a/lib/widgets/modular_widgets/transfer_widgets/receive/receive_large.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/receive/receive_large.dart
@@ -1,3 +1,4 @@
+
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/blocs.dart';
@@ -180,9 +181,10 @@ class _ReceiveLargeCardState extends State<ReceiveLargeCard> {
   }
 
   String _getQrString() {
-    return '${_selectedToken.symbol.toLowerCase()}:$_selectedSelfAddress?zts='
-        '${_selectedToken.tokenStandard}'
+    var qrData = '${_selectedToken.symbol.toLowerCase()}:'
+        '$_selectedSelfAddress?zts=${_selectedToken.tokenStandard}'
         '&amount=${_getAmount()}';
+    return qrData.substring(0, min(qrData.length, 122));
   }
 
   BigInt _getAmount() {

--- a/lib/widgets/modular_widgets/transfer_widgets/receive/receive_medium.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/receive/receive_medium.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/blocs.dart';
@@ -124,7 +125,11 @@ class _ReceiveMediumCardState extends State<ReceiveMediumCard> {
                         key: _amountKey,
                         autovalidateMode: AutovalidateMode.onUserInteraction,
                         child: InputField(
-                          validator: InputValidators.validateAmount,
+                          validator: (value) => InputValidators.correctValue(
+                              value,
+                              kBigP255m1,
+                              _selectedToken.decimals,
+                              BigInt.zero),
                           onChanged: (value) => setState(() {}),
                           inputFormatters:
                               FormatUtils.getAmountTextInputFormatters(

--- a/lib/widgets/modular_widgets/transfer_widgets/receive/receive_medium.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/receive/receive_medium.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/blocs.dart';
@@ -167,9 +168,10 @@ class _ReceiveMediumCardState extends State<ReceiveMediumCard> {
   }
 
   String _getQrString() {
-    return '${_selectedToken.symbol.toLowerCase()}:'
+    var qrData = '${_selectedToken.symbol.toLowerCase()}:'
         '$_selectedSelfAddress?zts=${_selectedToken.tokenStandard}'
         '&amount=${_getAmount()}';
+    return qrData.substring(0, min(qrData.length, 122));
   }
 
   BigInt _getAmount() {

--- a/lib/widgets/modular_widgets/transfer_widgets/receive/receive_medium.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/receive/receive_medium.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
-import 'package:lottie/lottie.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/blocs.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/constants.dart';
@@ -23,7 +22,6 @@ class ReceiveMediumCard extends StatefulWidget {
 }
 
 class _ReceiveMediumCardState extends State<ReceiveMediumCard> {
-  final int _maxQrCodeInputLength = 122;
   final TextEditingController _transferAddrController = TextEditingController();
   final TextEditingController _amountController = TextEditingController();
 
@@ -96,43 +94,12 @@ class _ReceiveMediumCardState extends State<ReceiveMediumCard> {
                 const SizedBox(
                   width: 20.0,
                 ),
-                _getQrString().length <= _maxQrCodeInputLength
-                    ? ReceiveQrImage(
-                        data: _getQrString(),
-                        size: 110.0,
-                        tokenStandard: _selectedToken.tokenStandard,
-                        context: context,
-                      )
-                    : Container(
-                        width: 130.0,
-                        height: 130.0,
-                        decoration: const BoxDecoration(
-                          color: AppColors.backgroundDark,
-                          borderRadius: BorderRadius.all(
-                            Radius.circular(15.0),
-                          ),
-                        ),
-                        child: Center(
-                          child: Padding(
-                            padding: const EdgeInsets.all(5.0),
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Lottie.asset(
-                                  'assets/lottie/ic_anim_no_data.json',
-                                  width: 32.0,
-                                  height: 32.0,
-                                ),
-                                Text(
-                                  'Input is too long for QR code',
-                                  textAlign: TextAlign.center,
-                                  style: Theme.of(context).textTheme.bodyMedium,
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
+                ReceiveQrImage(
+                  data: _getQrString(),
+                  size: 110,
+                  tokenStandard: _selectedToken.tokenStandard,
+                  context: context,
+                ),
                 const SizedBox(
                   width: 20.0,
                 ),

--- a/lib/widgets/modular_widgets/transfer_widgets/receive/receive_medium.dart
+++ b/lib/widgets/modular_widgets/transfer_widgets/receive/receive_medium.dart
@@ -1,7 +1,6 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
+import 'package:lottie/lottie.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/blocs.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/constants.dart';
@@ -24,6 +23,7 @@ class ReceiveMediumCard extends StatefulWidget {
 }
 
 class _ReceiveMediumCardState extends State<ReceiveMediumCard> {
+  final int _maxQrCodeInputLength = 122;
   final TextEditingController _transferAddrController = TextEditingController();
   final TextEditingController _amountController = TextEditingController();
 
@@ -96,12 +96,43 @@ class _ReceiveMediumCardState extends State<ReceiveMediumCard> {
                 const SizedBox(
                   width: 20.0,
                 ),
-                ReceiveQrImage(
-                  data: _getQrString(),
-                  size: 110.0,
-                  tokenStandard: _selectedToken.tokenStandard,
-                  context: context,
-                ),
+                _getQrString().length <= _maxQrCodeInputLength
+                    ? ReceiveQrImage(
+                        data: _getQrString(),
+                        size: 110.0,
+                        tokenStandard: _selectedToken.tokenStandard,
+                        context: context,
+                      )
+                    : Container(
+                        width: 130.0,
+                        height: 130.0,
+                        decoration: const BoxDecoration(
+                          color: AppColors.backgroundDark,
+                          borderRadius: BorderRadius.all(
+                            Radius.circular(15.0),
+                          ),
+                        ),
+                        child: Center(
+                          child: Padding(
+                            padding: const EdgeInsets.all(5.0),
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Lottie.asset(
+                                  'assets/lottie/ic_anim_no_data.json',
+                                  width: 32.0,
+                                  height: 32.0,
+                                ),
+                                Text(
+                                  'Input is too long for QR code',
+                                  textAlign: TextAlign.center,
+                                  style: Theme.of(context).textTheme.bodyMedium,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
                 const SizedBox(
                   width: 20.0,
                 ),
@@ -173,10 +204,9 @@ class _ReceiveMediumCardState extends State<ReceiveMediumCard> {
   }
 
   String _getQrString() {
-    var qrData = '${_selectedToken.symbol.toLowerCase()}:'
+    return '${_selectedToken.symbol.toLowerCase()}:'
         '$_selectedSelfAddress?zts=${_selectedToken.tokenStandard}'
         '&amount=${_getAmount()}';
-    return qrData.substring(0, min(qrData.length, 122));
   }
 
   BigInt _getAmount() {

--- a/lib/widgets/reusable_widgets/receive_qr_image.dart
+++ b/lib/widgets/reusable_widgets/receive_qr_image.dart
@@ -1,12 +1,13 @@
 import 'dart:io';
 import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_vector_icons/flutter_vector_icons.dart';
+import 'package:lottie/lottie.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:path/path.dart' as path;
 import 'package:pretty_qr_code/pretty_qr_code.dart';
-import 'package:screenshot/screenshot.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/color_utils.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/utils.dart';
@@ -15,13 +16,16 @@ import 'package:znn_sdk_dart/znn_sdk_dart.dart';
 
 class ReceiveQrImage extends StatelessWidget {
   final String data;
-  final double size;
+  final int size;
   final TokenStandard tokenStandard;
   final BuildContext context;
 
-  final ScreenshotController screenshotController = ScreenshotController();
+  static const decorationImage = PrettyQrDecorationImage(
+    image: AssetImage('assets/images/qr_code_child_image_znn.png'),
+    position: PrettyQrDecorationImagePosition.embedded,
+  );
 
-  ReceiveQrImage({
+  const ReceiveQrImage({
     required this.data,
     required this.size,
     required this.tokenStandard,
@@ -31,128 +35,162 @@ class ReceiveQrImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Screenshot(
-        controller: screenshotController,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(
-            15.0,
-          ),
-          child: Container(
-            padding: const EdgeInsets.all(
-              10.0,
-            ),
-            color: Theme.of(context).colorScheme.background,
-            child: ContextMenuRegion(
-              contextMenuBuilder: (context, offset) {
-                return AdaptiveTextSelectionToolbar(
-                  anchors: TextSelectionToolbarAnchors(
-                    primaryAnchor: offset,
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(
+        15.0,
+      ),
+      child: Container(
+        height: size + 20,
+        width: size + 20,
+        padding: const EdgeInsets.all(
+          10.0,
+        ),
+        color: Theme.of(context).colorScheme.background,
+        child: ContextMenuRegion(
+            contextMenuBuilder: (context, offset) {
+              return AdaptiveTextSelectionToolbar(
+                anchors: TextSelectionToolbarAnchors(
+                  primaryAnchor: offset,
+                ),
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Directionality(
+                          textDirection: TextDirection.rtl,
+                          child: TextButton.icon(
+                            icon: Icon(
+                              MaterialCommunityIcons.share,
+                              color: Theme.of(context).colorScheme.onBackground,
+                              size: 14,
+                            ),
+                            onPressed: () {
+                              ContextMenuController.removeAny();
+                              _shareQR();
+                            },
+                            style: TextButton.styleFrom(
+                              shape: const RoundedRectangleBorder(),
+                            ),
+                            label: Text(
+                                AdaptiveTextSelectionToolbar.getButtonLabel(
+                                    context,
+                                    ContextMenuButtonItem(
+                                        label: 'Share QR', onPressed: () {})),
+                                style: Theme.of(context).textTheme.bodyMedium),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Directionality(
-                            textDirection: TextDirection.rtl,
-                            child: TextButton.icon(
-                              icon: Icon(
-                                MaterialCommunityIcons.share,
-                                color:
-                                    Theme.of(context).colorScheme.onBackground,
-                                size: 14,
-                              ),
-                              onPressed: () {
-                                ContextMenuController.removeAny();
-                                _shareQR();
-                              },
-                              style: TextButton.styleFrom(
-                                shape: const RoundedRectangleBorder(),
-                              ),
-                              label: Text(
-                                  AdaptiveTextSelectionToolbar.getButtonLabel(
-                                      context,
-                                      ContextMenuButtonItem(
-                                          label: 'Share QR', onPressed: () {})),
-                                  style:
-                                      Theme.of(context).textTheme.bodyMedium),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Expanded(
+                        flex: 1,
+                        child: Directionality(
+                          textDirection: TextDirection.rtl,
+                          child: TextButton.icon(
+                            icon: Icon(
+                              Icons.save_alt,
+                              color: Theme.of(context).colorScheme.onBackground,
+                              size: 14,
                             ),
+                            onPressed: () {
+                              ContextMenuController.removeAny();
+                              _saveQR();
+                            },
+                            style: TextButton.styleFrom(
+                              shape: const RoundedRectangleBorder(),
+                            ),
+                            label: Text(
+                                AdaptiveTextSelectionToolbar.getButtonLabel(
+                                    context,
+                                    ContextMenuButtonItem(
+                                        label: 'Save QR', onPressed: () {})),
+                                style: Theme.of(context).textTheme.bodyMedium),
                           ),
                         ),
-                      ],
-                    ),
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        Expanded(
-                          flex: 1,
-                          child: Directionality(
-                            textDirection: TextDirection.rtl,
-                            child: TextButton.icon(
-                              icon: Icon(
-                                Icons.save_alt,
-                                color:
-                                    Theme.of(context).colorScheme.onBackground,
-                                size: 14,
-                              ),
-                              onPressed: () {
-                                ContextMenuController.removeAny();
-                                _saveQR();
-                              },
-                              style: TextButton.styleFrom(
-                                shape: const RoundedRectangleBorder(),
-                              ),
-                              label: Text(
-                                  AdaptiveTextSelectionToolbar.getButtonLabel(
-                                      context,
-                                      ContextMenuButtonItem(
-                                          label: 'Save QR', onPressed: () {})),
-                                  style:
-                                      Theme.of(context).textTheme.bodyMedium),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                );
-              },
-              child: PrettyQr(
+                      ),
+                    ],
+                  ),
+                ],
+              );
+            },
+            child: PrettyQrView.data(
                 data: data,
-                size: size,
-                elementColor: ColorUtils.getTokenColor(tokenStandard),
-                image: const AssetImage(
-                    'assets/images/qr_code_child_image_znn.png'),
-                typeNumber: 7,
+                decoration: PrettyQrDecoration(
+                    shape: PrettyQrSmoothSymbol(
+                      roundFactor: 0,
+                      color: ColorUtils.getTokenColor(tokenStandard),
+                    ),
+                    image: decorationImage),
                 errorCorrectLevel: QrErrorCorrectLevel.M,
-                roundEdges: true,
-              ),
+                errorBuilder: (context, error, stack) => Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(5.0),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Lottie.asset(
+                              'assets/lottie/ic_anim_no_data.json',
+                              width: 32.0,
+                              height: 32.0,
+                            ),
+                            Tooltip(
+                                message: error.toString(),
+                                child: Text(
+                                  'Failed to create QR code',
+                                  textAlign: TextAlign.center,
+                                  style: Theme.of(context).textTheme.bodyMedium,
+                                )),
+                          ],
+                        ),
+                      ),
+                    ))),
+      ),
+    );
+  }
+
+  Future<Uint8List?> _getQRImageData() async {
+    final qr = QrImage(QrCode.fromData(
+      data: data,
+      errorCorrectLevel: QrErrorCorrectLevel.M,
+    ));
+
+    final b = await qr.toImageAsBytes(
+        size: size,
+        format: ImageByteFormat.png,
+        decoration: PrettyQrDecoration(
+            shape: PrettyQrSmoothSymbol(
+              roundFactor: 0,
+              color: ColorUtils.getTokenColor(tokenStandard),
             ),
-          ),
-        ));
+            image: decorationImage));
+
+    if (b != null) return b.buffer.asUint8List();
+    return null;
   }
 
   void _saveQR() async {
-    Uint8List? capture = await screenshotController.capture(
-        delay: const Duration(milliseconds: 20));
-    if (capture != null) {
+    final imageData = await _getQRImageData();
+    if (imageData != null) {
       String fileName = DateTime.now().millisecondsSinceEpoch.toString();
       final imagePath = await File(
               '${znnDefaultPaths.cache.path}${path.separator}$fileName.png')
           .create();
-      await imagePath.writeAsBytes(capture);
+      await imagePath.writeAsBytes(imageData);
       await OpenFilex.open(imagePath.path);
     }
   }
 
   void _shareQR() async {
-    Uint8List? capture = await screenshotController.capture(
-        delay: const Duration(milliseconds: 20));
-    if (capture != null) {
+    final imageData = await _getQRImageData();
+    if (imageData != null) {
       String fileName = DateTime.now().millisecondsSinceEpoch.toString();
       final imagePath = await File(
               '${znnDefaultPaths.cache.path}${path.separator}$fileName.png')
           .create();
-      await imagePath.writeAsBytes(capture);
+      await imagePath.writeAsBytes(imageData);
       await Share.shareXFiles([XFile(imagePath.path)]);
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1015,10 +1015,10 @@ packages:
     dependency: "direct main"
     description:
       name: pretty_qr_code
-      sha256: ea7ccb3069e0f5b89b441449b9ec10f4148ddda7a4bef89a130d2ebdaa0be647
+      sha256: "47a0fde3967e01ea31985d1a11a998fab1ab900becdba592e9abb0a4034b807e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "3.2.1"
   provider:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   share_plus: ^7.0.2
   page_transition: ^2.0.4
   file_selector: ^0.9.2+2
-  pretty_qr_code: ^2.0.3
+  pretty_qr_code: ^3.2.1
   screenshot: ^2.1.0
   desktop_drop: ^0.4.0
   validators: ^3.0.0


### PR DESCRIPTION
This PR fixes issue #28 

- Updated `pretty_qr_code` package to version 3.2.1 which improves image quality
- Use `errorBuilder` to handle all possible errors and not only the maximum length error
- Save and share use `pretty_qr_code` directly to generate the QR image data instead of screenshot
- Maximum length for the medium transfer widget is now around `18772` bytes instead of `122`
- The InputValidator has been changed to use the `InputValidator.correctValue` for proper handeling of decimals.