### PR TITLE
Delay starting Embedded Node until confirmed

### DIFF
--- a/lib/screens/node_management_screen.dart
+++ b/lib/screens/node_management_screen.dart
@@ -44,8 +44,8 @@ class _NodeManagementScreenState extends State<NodeManagementScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _selectedNode ??= kCurrentNode!;
-    _selectedNodeConfirmed = _selectedNode!;
+    _selectedNode ??= kCurrentNode ?? kEmbeddedNode;
+    _selectedNodeConfirmed = _selectedNode ?? kEmbeddedNode;
   }
 
   @override
@@ -140,12 +140,12 @@ class _NodeManagementScreenState extends State<NodeManagementScreen> {
 
     try {
       _confirmNodeButtonKey.currentState?.animateForward();
-      String url = _selectedNode == 'Embedded Node'
+      String url = _selectedNode == kEmbeddedNode
           ? kLocalhostDefaultNodeUrl
           : _selectedNode!;
       bool isConnectionEstablished =
           await NodeUtils.establishConnectionToNode(url);
-      if (_selectedNode == 'Embedded Node') {
+      if (_selectedNode == kEmbeddedNode) {
         // Check if node is already running
         if (!isConnectionEstablished) {
           // Initialize local full node

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -120,6 +120,7 @@ const List<int> kPowerUsersPlasmaRequirements = [
   kIssueTokenPlasmaAmountNeeded,
 ];
 
+const String kEmbeddedNode = 'Embedded Node';
 const String kLocalhostDefaultNodeUrl = 'ws://127.0.0.1:$kDefaultPort';
 const int kDefaultPort = 35998;
 

--- a/lib/utils/global.dart
+++ b/lib/utils/global.dart
@@ -57,7 +57,7 @@ final List<Tabs> kDisabledTabs = [
 ];
 
 List<String> kDefaultNodes = [
-  'Embedded Node',
+  kEmbeddedNode,
   kLocalhostDefaultNodeUrl,
 ];
 

--- a/lib/utils/node_utils.dart
+++ b/lib/utils/node_utils.dart
@@ -46,14 +46,14 @@ class NodeUtils {
     }
 
     if (kCurrentNode == kLocalhostDefaultNodeUrl ||
-        kCurrentNode == 'Embedded Node') {
+        kCurrentNode == kEmbeddedNode) {
       if (kEmbeddedNodeRunning) {
         sl.get<NotificationsBloc>().addNotification(
               WalletNotification(
-                title: 'Waiting for embedded node to stop',
+                title: 'Waiting for Embedded Node to stop',
                 timestamp: DateTime.now().millisecondsSinceEpoch,
                 details:
-                    'The app will close after the embedded node has been stopped',
+                    'The app will close after the Embedded Node has been stopped',
                 type: NotificationType.changedNode,
               ),
             );
@@ -79,7 +79,7 @@ class NodeUtils {
 
   static initWebSocketClient() async {
     addOnWebSocketConnectedCallback();
-    var url = kCurrentNode!;
+    var url = kCurrentNode ?? kLocalhostDefaultNodeUrl;
     bool connected = false;
     try {
       connected = await establishConnectionToNode(url);
@@ -204,21 +204,19 @@ class NodeUtils {
     kDbNodes.addAll(nodesBox.values);
     // Handle the case in which some default nodes were deleted
     // so they can't be found in the cache
-    String currentNode = kCurrentNode!;
-    if (!kDefaultNodes.contains(currentNode) &&
+    String? currentNode = kCurrentNode;
+    if (currentNode != null &&
+        !kDefaultNodes.contains(currentNode) &&
         !kDbNodes.contains(currentNode)) {
       kDefaultNodes.add(currentNode);
     }
   }
 
   static Future<void> setNode() async {
-    String savedNode = sharedPrefsService!.get(
-      kSelectedNodeKey,
-      defaultValue: kDefaultNodes.first,
-    );
+    String? savedNode = sharedPrefsService!.get(kSelectedNodeKey);
     kCurrentNode = savedNode;
 
-    if (savedNode == 'Embedded Node') {
+    if (savedNode == kEmbeddedNode) {
       // First we need to check if the node is not already running
       bool isConnectionEstablished =
           await NodeUtils.establishConnectionToNode(kLocalhostDefaultNodeUrl);

--- a/lib/widgets/modular_widgets/settings_widgets/node_management.dart
+++ b/lib/widgets/modular_widgets/settings_widgets/node_management.dart
@@ -71,7 +71,7 @@ class _NodeManagementState extends State<NodeManagement> {
       title: 'Node Management',
       description:
           'This card allows one to set the ZNN Node used to connect to. '
-          'By default the wallet is connected to the embedded node. '
+          'By default the wallet is connected to the Embedded Node. '
           'If you are running a local ZNN Node, please use the localhost option',
       childBuilder: () => _getWidgetBody(),
     );
@@ -127,12 +127,12 @@ class _NodeManagementState extends State<NodeManagement> {
 
     try {
       _confirmNodeButtonKey.currentState?.animateForward();
-      String url = _selectedNode == 'Embedded Node'
+      String url = _selectedNode == kEmbeddedNode
           ? kLocalhostDefaultNodeUrl
           : _selectedNode!;
       bool isConnectionEstablished =
           await NodeUtils.establishConnectionToNode(url);
-      if (_selectedNode == 'Embedded Node') {
+      if (_selectedNode == kEmbeddedNode) {
         // Check if node is already running
         if (!isConnectionEstablished) {
           // Initialize local full node


### PR DESCRIPTION
This PR delays starting the Embedded Node until it is confirmed at the Node Management screen.

The Embedded Node is started by default before confirmation of the node at the node management screen. This causes a couple of issues:

1. Possibly unnecessary synchronization takes place, causing high CPU usage and network bandwidth
1. The local port `35998` is opened by default when starting syrius, preventing someone to start `znnd` locally
1. Embedded Node needs to be stopped when another node is confirmed, sometimes causing long delays
1. Allows to connect to `ws://127.0.0.1:35998` before stopping Embedded Node, resulting in `JSON-RPC error -32000: method handler crashed` messages

**Changes**
- Replaced the `Embedded Node` name with `kEmbeddedNode` constant
- The `NodeUtils.setNode` function uses `null` by default instead of `Embedded Node` when it cannot find a saved node.
- The Node Management screen uses `Embedded Node` by default when the current selected node is `null`.
- Replaced all occurrences of `embedded node` with `Embedded Node`.