### PR TITLE
Reset words when verify incorrect seed

### DIFF
--- a/lib/screens/onboarding/new_wallet/new_wallet_confirm_seed_screen.dart
+++ b/lib/screens/onboarding/new_wallet/new_wallet_confirm_seed_screen.dart
@@ -350,16 +350,22 @@ class _NewWalletConfirmSeedScreenState
     for (var element in _seedGridElements) {
       int i = _seedGridElements.indexOf(element);
       element.isValid = element.word == widget.seedWords[i];
-    }
-    for (var item in _seedGridElements) {
-      if (!item.isValid) {
-        setState(() {
-          _seedError = true;
-        });
-        break;
+      if (!element.isValid) {
+        _seedError = true;
       }
     }
+    if (_seedError) {
+      for (var element in _seedGridElements) {
+        int i = _seedGridElements.indexOf(element);
+        if (_randomIndexes.contains(i)) {
+          element.isValid = false;
+          element.word = '';
+        }
+      }
+    }
+
     setState(() {
+      _seedError = true;
       _foundMissingRandomElementsIndexes = _randomIndexes
           .where((index) => _seedGridElements[index].isValid)
           .toList();

--- a/lib/screens/onboarding/new_wallet/new_wallet_confirm_seed_screen.dart
+++ b/lib/screens/onboarding/new_wallet/new_wallet_confirm_seed_screen.dart
@@ -263,11 +263,27 @@ class _NewWalletConfirmSeedScreenState
                       !seedGridElement.isValid;
                 },
                 onAccept: (String data) {
-                  _foundMissingRandomElementsIndexes
-                      .add(widget.seedWords.indexOf(data));
-                  _seedGridElements[seedGridElementIndex].word = data;
-                  if (_randomIndexes.length ==
-                      _foundMissingRandomElementsIndexes.length) {}
+                  var element = _seedGridElements[seedGridElementIndex];
+                  var i = -1;
+                  if (element.word != '') {
+                    while ((i =
+                            widget.seedWords.indexOf(element.word, i + 1)) !=
+                        -1) {
+                      if (_foundMissingRandomElementsIndexes.contains(i)) {
+                        _foundMissingRandomElementsIndexes.remove(i);
+                        break;
+                      }
+                    }
+                  }
+                  i = -1;
+                  while ((i = widget.seedWords.indexOf(data, i + 1)) != -1) {
+                    if (!_foundMissingRandomElementsIndexes.contains(i) &&
+                        _randomIndexes.contains(i)) {
+                      _foundMissingRandomElementsIndexes.add(i);
+                      break;
+                    }
+                  }
+                  element.word = data;
                   setState(() {
                     _textCursor = seedGridElementIndex;
                   });


### PR DESCRIPTION
This PR fixes issue https://github.com/zenon-network/syrius/issues/60

The old implementation maintained the words after verification of the seed. This makes it easier to place the words into the correct fields one by one until the seed is correct. It makes more sense not to give any hints about which words were right or wrong. The verification should either be correct or completely wrong.

**Changes**
1. When the seed is verified and deemed valid
    - all random input fields are shown as correct (green)
    - verify button changes to continue

2. When the seed is verified and deemed invalid
    - all random input fields are shown as incorrect (red)
    - all random words are removed from the input fields and returned to the available words

3. Fixes
    - Seed with double words are now handled correctly 
    - Dropping a word on another word returns the overwritten word to the available words