### PR TITLE
Change AZ pillar owner filters

### DIFF
--- a/lib/widgets/modular_widgets/accelerator_widgets/accelerator_project_list_item.dart
+++ b/lib/widgets/modular_widgets/accelerator_widgets/accelerator_project_list_item.dart
@@ -72,6 +72,7 @@ class _AcceleratorProjectListItemState
               hash: widget.acceleratorProject.id,
               creationTimestamp: widget.acceleratorProject.creationTimestamp,
               acceleratorProjectStatus: widget.acceleratorProject.status,
+              isPhase: widget.acceleratorProject is Phase
             ),
             const SizedBox(
               height: 10.0,

--- a/lib/widgets/modular_widgets/accelerator_widgets/project_list.dart
+++ b/lib/widgets/modular_widgets/accelerator_widgets/project_list.dart
@@ -12,7 +12,7 @@ import 'package:znn_sdk_dart/znn_sdk_dart.dart';
 enum AccProjectsFilterTag {
   myProjects,
   onlyAccepted,
-  votingOpened,
+  needsVoting,
   alreadyVoted,
 }
 
@@ -168,7 +168,7 @@ class _AccProjectListState extends State<AccProjectList> {
     for (var tag in AccProjectsFilterTag.values) {
       if (widget.pillarInfo == null) {
         if ([
-          AccProjectsFilterTag.votingOpened,
+          AccProjectsFilterTag.needsVoting,
           AccProjectsFilterTag.alreadyVoted
         ].contains(tag)) {
           continue;

--- a/lib/widgets/modular_widgets/accelerator_widgets/projects_stats.dart
+++ b/lib/widgets/modular_widgets/accelerator_widgets/projects_stats.dart
@@ -37,7 +37,7 @@ class ProjectsStats extends StatelessWidget {
                   AcceleratorProjectDetails(
                     owner: project.owner,
                     hash: project.id,
-                    creationTimestamp: null,
+                    creationTimestamp: project.creationTimestamp
                   ),
                 ],
               ),

--- a/lib/widgets/reusable_widgets/accelerator_project_details.dart
+++ b/lib/widgets/reusable_widgets/accelerator_project_details.dart
@@ -10,12 +10,14 @@ class AcceleratorProjectDetails extends StatelessWidget {
   final Hash? hash;
   final int? creationTimestamp;
   final AcceleratorProjectStatus? acceleratorProjectStatus;
+  final bool isPhase;
 
   const AcceleratorProjectDetails({
     this.owner,
     this.hash,
     this.creationTimestamp,
     this.acceleratorProjectStatus,
+    this.isPhase = false,
     Key? key,
   }) : super(key: key);
 
@@ -44,7 +46,8 @@ class AcceleratorProjectDetails extends StatelessWidget {
         'Created ${_formatData(creationTimestamp! * 1000)}',
         style: Theme.of(context).inputDecorationTheme.hintStyle,
       ));
-      if (acceleratorProjectStatus != null &&
+      if (!isPhase &&
+          acceleratorProjectStatus != null &&
           acceleratorProjectStatus == AcceleratorProjectStatus.voting) {
         children.add(Text(
           _getTimeUntilVotingCloses(),


### PR DESCRIPTION
This PR changes the `voting opened` and `already voted` AZ project filters to make it easier for pillar owners to find projects or projects with phases that needs voting. See issue #67 

The old definition of the filters `voting opened` and `already voted` are as follows:
- `voting opened`
    all projects that needs voting and have not been voted on.
- `already voted`
    all projects that have been voted on.

The new definition of the filters `needs voting` and `already voted` are as follows:
- `needs voting`
    all projects or projects with phases that needs voting and have not been voted on.
- `already voted`
    all projects or projects with phases that needs voting and have been voted on.

**Changes**
- The `voting opened` filter has been renamed to `needs voting`.
- The `needs voting` definition has been changed to include phases that needs voting and have not been voted on.
- The `already voted` definition has been change to include phases that needs voting and have been voted on.

**Additional changes**
- Hide time until voting for phases
- Show creation time in project stats