### PR TITLE
Rearrange settings widgets

### DIFF
--- a/lib/widgets/tab_children_widgets/settings_tab_child.dart
+++ b/lib/widgets/tab_children_widgets/settings_tab_child.dart
@@ -45,37 +45,13 @@ class _SettingsTabChildState extends State<SettingsTabChild> {
             accountChainStatsBloc: _accountChainStatsBloc,
           ),
         ),
-        FluidCell(
-          width: context.layout.value(
-            xl: kStaggeredNumOfColumns ~/ 2,
-            lg: kStaggeredNumOfColumns ~/ 2,
-            md: kStaggeredNumOfColumns ~/ 2,
-            sm: kStaggeredNumOfColumns,
-            xs: kStaggeredNumOfColumns,
-          ),
-          child: const PeersWidget(),
-        ),
         const FluidCell(
           child: GeneralWidget(),
-          height: kStaggeredNumOfColumns / 3,
         ),
         FluidCell(
           child: AccountChainStatsWidget(
             accountChainStatsBloc: _accountChainStatsBloc,
           ),
-          height: kStaggeredNumOfColumns / 3,
-        ),
-        FluidCell(
-          child: SecurityWidget(
-            widget._onChangeAutoLockTime,
-            onStepperNotificationSeeMorePressed:
-                widget.onStepperNotificationSeeMorePressed,
-          ),
-          height: kStaggeredNumOfColumns / 3,
-        ),
-        const FluidCell(
-          child: WalletOptions(),
-          height: kStaggeredNumOfColumns / 3,
         ),
         FluidCell(
           width: context.layout.value(
@@ -88,15 +64,65 @@ class _SettingsTabChildState extends State<SettingsTabChild> {
           child: NodeManagement(
             onNodeChangedCallback: widget.onNodeChangedCallback,
           ),
-          height: kStaggeredNumOfColumns / 3,
+          height: kStaggeredNumOfColumns / 4,
         ),
-        const FluidCell(
-          child: DisplayWidget(),
-          height: kStaggeredNumOfColumns / 3,
+        FluidCell(
+          width: context.layout.value(
+            xl: kStaggeredNumOfColumns ~/ 6,
+            lg: kStaggeredNumOfColumns ~/ 6,
+            md: kStaggeredNumOfColumns ~/ 6,
+            sm: kStaggeredNumOfColumns,
+            xs: kStaggeredNumOfColumns,
+          ),
+          child: SecurityWidget(
+            widget._onChangeAutoLockTime,
+            onStepperNotificationSeeMorePressed:
+                widget.onStepperNotificationSeeMorePressed,
+          ),
+          height: kStaggeredNumOfColumns / 2
         ),
-        const FluidCell(
-          child: BackupWidget(),
-          height: kStaggeredNumOfColumns / 3,
+        FluidCell(
+          width: context.layout.value(
+            xl: kStaggeredNumOfColumns ~/ 6,
+            lg: kStaggeredNumOfColumns ~/ 6,
+            md: kStaggeredNumOfColumns ~/ 6,
+            sm: kStaggeredNumOfColumns,
+            xs: kStaggeredNumOfColumns,
+          ),
+          child: const DisplayWidget(),
+          height: kStaggeredNumOfColumns / 2
+        ),
+        FluidCell(
+          child: const WalletOptions(),
+          width: context.layout.value(
+            xl: kStaggeredNumOfColumns ~/ 6,
+            lg: kStaggeredNumOfColumns ~/ 6,
+            md: kStaggeredNumOfColumns ~/ 6,
+            sm: kStaggeredNumOfColumns,
+            xs: kStaggeredNumOfColumns,
+          ),
+          height: kStaggeredNumOfColumns / 4,
+        ),
+        FluidCell(
+          width: context.layout.value(
+            xl: kStaggeredNumOfColumns ~/ 2,
+            lg: kStaggeredNumOfColumns ~/ 2,
+            md: kStaggeredNumOfColumns ~/ 2,
+            sm: kStaggeredNumOfColumns,
+            xs: kStaggeredNumOfColumns,
+          ),
+          child: const PeersWidget(),
+        ),
+        FluidCell(
+          child: const BackupWidget(),
+          width: context.layout.value(
+            xl: kStaggeredNumOfColumns ~/ 6,
+            lg: kStaggeredNumOfColumns ~/ 6,
+            md: kStaggeredNumOfColumns ~/ 6,
+            sm: kStaggeredNumOfColumns,
+            xs: kStaggeredNumOfColumns,
+          ),
+          height: kStaggeredNumOfColumns / 4,
         ),
       ],
     );


### PR DESCRIPTION
This PR implements issue https://github.com/zenon-network/syrius/issues/80 and proposes a new Widget arrangement for the Settings layout.

![settings-layout-top](https://github.com/zenon-network/syrius/assets/13164589/8330fccb-031b-47e7-a4bd-633d9002eac1)

![settings-layout-bottom](https://github.com/zenon-network/syrius/assets/13164589/453d9d1c-6693-4bf8-ae18-3cde76e561f3)
