### PR TITLE
Use wallet name to identify ledger device

### DIFF
--- a/lib/blocs/ledger_wallet_file_bloc.dart
+++ b/lib/blocs/ledger_wallet_file_bloc.dart
@@ -9,13 +9,11 @@ import 'package:zenon_syrius_wallet_flutter/utils/wallet_file.dart';
 import 'package:znn_sdk_dart/znn_sdk_dart.dart';
 
 class LedgerWalletFileBloc extends BaseBloc<LedgerWalletFile?> {
-  Future<void> getLedgerWalletPath(
-    String walletId,
-    String password,
-  ) async {
+  Future<void> getLedgerWalletPath(String walletId, String password,
+      String? walletName) async {
     try {
-      await WalletUtils.createLedgerWalletFile(
-          walletId, password);
+      await WalletUtils.createLedgerWalletFile(walletId, password,
+          walletName: walletName);
       await InitUtils.initWalletAfterDecryption(
           Crypto.digest(utf8.encode(password)));
       addEvent(kWalletFile as LedgerWalletFile);

--- a/lib/screens/onboarding/create_ledger_screen.dart
+++ b/lib/screens/onboarding/create_ledger_screen.dart
@@ -4,21 +4,23 @@ import 'package:zenon_syrius_wallet_flutter/screens/screens.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/utils.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/wallet_file.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/widgets.dart';
+import 'package:znn_sdk_dart/znn_sdk_dart.dart';
 
 class CreateLedgerWalletScreen extends StatefulWidget {
-  final String walletId;
+  final WalletDefinition deviceInfo;
   final String password;
   final int progressBarNumLevels;
 
   const CreateLedgerWalletScreen(
-    this.walletId,
+    this.deviceInfo,
     this.password, {
     this.progressBarNumLevels = 4,
     Key? key,
   }) : super(key: key);
 
   @override
-  State<CreateLedgerWalletScreen> createState() => _CreateLedgerWalletScreenState();
+  State<CreateLedgerWalletScreen> createState() =>
+      _CreateLedgerWalletScreenState();
 }
 
 class _CreateLedgerWalletScreenState extends State<CreateLedgerWalletScreen> {
@@ -29,8 +31,9 @@ class _CreateLedgerWalletScreenState extends State<CreateLedgerWalletScreen> {
     super.initState();
     _ledgerWalletFileBloc = LedgerWalletFileBloc()
       ..getLedgerWalletPath(
-        widget.walletId,
+        widget.deviceInfo.walletId,
         widget.password,
+        widget.deviceInfo.walletName,
       );
   }
 

--- a/lib/screens/onboarding/hardware_wallet/hardware_wallet_device_choice_screen.dart
+++ b/lib/screens/onboarding/hardware_wallet/hardware_wallet_device_choice_screen.dart
@@ -322,7 +322,7 @@ class _HardwareWalletDeviceChoiceScreenState
               ? () {
                   NavigationUtils.push(
                     context,
-                    HardwareWalletPasswordScreen(_selectedDevice!.walletId),
+                    HardwareWalletPasswordScreen(_selectedDevice!),
                   );
                 }
               : null,

--- a/lib/screens/onboarding/hardware_wallet/hardware_wallet_password_screen.dart
+++ b/lib/screens/onboarding/hardware_wallet/hardware_wallet_password_screen.dart
@@ -2,11 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:zenon_syrius_wallet_flutter/screens/onboarding/create_ledger_screen.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/utils.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/widgets.dart';
+import 'package:znn_sdk_dart/znn_sdk_dart.dart';
 
 class HardwareWalletPasswordScreen extends StatefulWidget {
-  final String walletId;
+  final WalletDefinition deviceInfo;
 
-  const HardwareWalletPasswordScreen(this.walletId, {Key? key}) : super(key: key);
+  const HardwareWalletPasswordScreen(this.deviceInfo, {Key? key}) : super(key: key);
 
   @override
   State<HardwareWalletPasswordScreen> createState() =>
@@ -115,7 +116,7 @@ class _HardwareWalletPasswordScreenState extends State<HardwareWalletPasswordScr
               NavigationUtils.push(
                 context,
                 CreateLedgerWalletScreen(
-                  widget.walletId,
+                  widget.deviceInfo,
                   _passwordController.text,
                 ),
               );

--- a/lib/utils/wallet_file.dart
+++ b/lib/utils/wallet_file.dart
@@ -149,7 +149,7 @@ class LedgerWalletFile extends WalletFile {
     }
     throw const LedgerError.connectionError(
         origMessage:
-            'Cannot find the hardware device, please connect the device on which the wallet is initialized');
+            'Cannot find the hardware device, please connect/unlock the device on which the wallet is initialized');
   }
 
   static Future<LedgerWalletFile> create(String walletId, String password,

--- a/lib/utils/wallet_utils.dart
+++ b/lib/utils/wallet_utils.dart
@@ -18,9 +18,10 @@ class WalletUtils {
   static Future<void> createLedgerWalletFile(
     String walletId,
     String password, {
-    String? name,
+    String? walletName,
   }) async {
-    kWalletFile = await LedgerWalletFile.create(walletId, password, name: name);
+    kWalletFile = await LedgerWalletFile.create(walletId, password,
+        walletName: walletName);
     kWalletPath = kWalletFile!.walletPath;
     await _storeWalletPath(kWalletFile!.walletPath);
   }


### PR DESCRIPTION
This PR fixes issue #87.

Due to security reasons ledger devices do not have an unique id like for example a serial number.

Syrius used the device path to try and the same device when reconnecting. The device path cannot be used on Linux and macOS because the device path changes on every reconnect or different usb port.

The implementation has been changed to use the wallet name to identify the ledger device.