### PR TITLE
Disconnect node on Wallet Reset

### DIFF
--- a/lib/screens/node_management_screen.dart
+++ b/lib/screens/node_management_screen.dart
@@ -232,8 +232,6 @@ class _NodeManagementScreenState extends State<NodeManagementScreen> {
               await NodeUtils.establishConnectionToNode(url);
         }
       } else {
-        isConnectionEstablished =
-            await NodeUtils.establishConnectionToNode(url);
         if (isConnectionEstablished) {
           await NodeUtils.closeEmbeddedNode();
         }

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -101,6 +101,7 @@ class _SplashScreenState extends State<SplashScreen>
     // after the user creates or imports a new wallet
     kWalletInitCompleted = false;
     await sl.get<NotificationsBloc>().addNotification(null);
+    NodeUtils.stopWebSocketClient();
     if (sl<AutoReceiveTxWorker>().pool.isNotEmpty) {
       sl<AutoReceiveTxWorker>().pool.clear();
     }

--- a/lib/utils/node_utils.dart
+++ b/lib/utils/node_utils.dart
@@ -77,15 +77,19 @@ class NodeUtils {
     }
   }
 
+  static stopWebSocketClient() {
+    try {
+      zenon!.wsClient.stop();
+    } catch (_) {}
+  }
+
   static initWebSocketClient() async {
     addOnWebSocketConnectedCallback();
-    var url = kCurrentNode ?? kLocalhostDefaultNodeUrl;
+    var url = kCurrentNode ?? '';
     bool connected = false;
     try {
       connected = await establishConnectionToNode(url);
-    } on WebSocketException {
-      url = kLocalhostDefaultNodeUrl;
-    }
+    } catch (_) {}
     if (!connected) {
       zenon!.wsClient.initialize(
         url,


### PR DESCRIPTION
This PR fixes issue https://github.com/zenon-network/syrius/issues/91

**Changes**
- The WebSocket client is initialized only when a node is explicitly confirmed using the node management
- The WebSocket client is closed on a Wallet Reset

