### PR TITLE
Fix dashboard highlight overlap

### DIFF
--- a/lib/widgets/main_app_container.dart
+++ b/lib/widgets/main_app_container.dart
@@ -199,7 +199,7 @@ class _MainAppContainerState extends State<MainAppContainer>
                   ),
                   child: Padding(
                     padding: const EdgeInsets.symmetric(
-                      horizontal: 10.0,
+                      horizontal: 12.0,
                     ),
                     child: Focus(
                       focusNode: _focusNode,


### PR DESCRIPTION
This PR fixes issue #86 

The clipping can be prevented by adding 2px extra padding to the navigation control.

**Before**
![syrius-navigation-border-clipping-2](https://github.com/zenon-network/syrius/assets/13164589/c9c25a09-811d-4e89-b893-1941eb1462ca)

**After**
![syrius-navigation-border-clipping-1](https://github.com/zenon-network/syrius/assets/13164589/70884a2d-2548-40aa-83ea-0adfcb07ab58)
