### PR TITLE
Fix "shadows" on token cards

### DIFF
--- a/lib/widgets/modular_widgets/token_widgets/token_card.dart
+++ b/lib/widgets/modular_widgets/token_widgets/token_card.dart
@@ -60,6 +60,7 @@ class _TokenCardState extends State<TokenCard> {
   final GlobalKey<LoadingButtonState> _transferButtonKey = GlobalKey();
 
   TokenCardBackVersion _backOfCardVersion = TokenCardBackVersion.burn;
+  bool _backOfCardVisible = false;
 
   @override
   void initState() {
@@ -71,13 +72,16 @@ class _TokenCardState extends State<TokenCard> {
   @override
   Widget build(BuildContext context) {
     return FlipCard(
-      direction: FlipDirection.HORIZONTAL,
-      speed: 500,
-      flipOnTouch: false,
-      key: _cardKey,
-      front: _getFrontOfCard(),
-      back: _getBackOfCard(),
-    );
+        direction: FlipDirection.HORIZONTAL,
+        speed: 500,
+        flipOnTouch: false,
+        key: _cardKey,
+        front: _getFrontOfCard(),
+        back: _getBackOfCard(),
+        onFlip: () => {
+              setState(
+                  () => _backOfCardVisible = _cardKey.currentState!.isFront)
+            });
   }
 
   Widget _getBackOfCard() {
@@ -376,50 +380,53 @@ class _TokenCardState extends State<TokenCard> {
       widget.token.tokenStandard,
     );
 
-    return ListView(
-      shrinkWrap: true,
-      children: [
-        Form(
-          key: _burnAmountKey,
-          autovalidateMode: AutovalidateMode.onUserInteraction,
-          child: InputField(
-            onChanged: (String value) {
-              setState(() {});
-            },
-            inputFormatters: FormatUtils.getAmountTextInputFormatters(
-              _burnAmountController.text,
+    return Visibility(
+      visible: _backOfCardVisible,
+      child: ListView(
+        shrinkWrap: true,
+        children: [
+          Form(
+            key: _burnAmountKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: InputField(
+              onChanged: (String value) {
+                setState(() {});
+              },
+              inputFormatters: FormatUtils.getAmountTextInputFormatters(
+                _burnAmountController.text,
+              ),
+              controller: _burnAmountController,
+              validator: (value) => InputValidators.correctValue(
+                  value, _burnMaxAmount, widget.token.decimals, BigInt.zero),
+              suffixIcon: _getAmountSuffix(),
+              suffixIconConstraints: const BoxConstraints(maxWidth: 50.0),
+              hintText: 'Amount',
+              contentLeftPadding: 20.0,
             ),
-            controller: _burnAmountController,
-            validator: (value) => InputValidators.correctValue(
-                value, _burnMaxAmount, widget.token.decimals, BigInt.zero),
-            suffixIcon: _getAmountSuffix(),
-            suffixIconConstraints: const BoxConstraints(maxWidth: 50.0),
-            hintText: 'Amount',
-            contentLeftPadding: 20.0,
           ),
-        ),
-        StepperUtils.getBalanceWidget(widget.token, accountInfo),
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Column(
-              children: [
-                _getBurnButtonViewModel(),
-                const SizedBox(
-                  height: 10.0,
-                ),
-                StepperButton(
-                  text: 'Go back',
-                  onPressed: () {
-                    _cardKey.currentState!.toggleCard();
-                  },
-                ),
-              ],
-            ),
-          ],
-        ),
-      ],
+          StepperUtils.getBalanceWidget(widget.token, accountInfo),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Column(
+                children: [
+                  _getBurnButtonViewModel(),
+                  const SizedBox(
+                    height: 10.0,
+                  ),
+                  StepperButton(
+                    text: 'Go back',
+                    onPressed: () {
+                      _cardKey.currentState!.toggleCard();
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 
@@ -450,7 +457,8 @@ class _TokenCardState extends State<TokenCard> {
     );
   }
 
-  Future<void> _sendBurnSuccessfulNotification(AccountBlockTemplate event) async {
+  Future<void> _sendBurnSuccessfulNotification(
+      AccountBlockTemplate event) async {
     await sl.get<NotificationsBloc>().addNotification(
           WalletNotification(
             title: 'Successfully burned ${event.amount.addDecimals(
@@ -518,67 +526,70 @@ class _TokenCardState extends State<TokenCard> {
   Widget _getMintBackOfCard(AccountInfo? accountInfo) {
     _mintMaxAmount = (widget.token.maxSupply - widget.token.totalSupply);
 
-    return ListView(
-      shrinkWrap: true,
-      children: [
-        Form(
-          key: _beneficiaryAddressKey,
-          autovalidateMode: AutovalidateMode.onUserInteraction,
-          child: InputField(
-            onChanged: (value) {
-              setState(() {});
-            },
-            inputFormatters: [
-              FilteringTextInputFormatter.allow(RegExp(r'[0-9a-z]')),
-            ],
-            controller: _beneficiaryAddressController,
-            hintText: 'Beneficiary address',
-            contentLeftPadding: 20.0,
-            validator: (value) => InputValidators.checkAddress(value),
-          ),
-        ),
-        StepperUtils.getBalanceWidget(widget.token, accountInfo!),
-        Form(
-          key: _mintAmountKey,
-          autovalidateMode: AutovalidateMode.onUserInteraction,
-          child: InputField(
-            onChanged: (value) {
-              setState(() {});
-            },
-            inputFormatters: FormatUtils.getAmountTextInputFormatters(
-              _mintAmountController.text,
-            ),
-            controller: _mintAmountController,
-            validator: (value) => InputValidators.correctValue(
-                value, _mintMaxAmount, widget.token.decimals, BigInt.zero),
-            suffixIcon: _getAmountSuffix(),
-            suffixIconConstraints: const BoxConstraints(maxWidth: 50.0),
-            hintText: 'Amount',
-            contentLeftPadding: 20.0,
-          ),
-        ),
-        kVerticalSpacing,
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Column(
-              children: [
-                _getMintButtonViewModel(),
-                const SizedBox(
-                  height: 10.0,
-                ),
-                StepperButton(
-                  text: 'Go back',
-                  onPressed: () {
-                    _cardKey.currentState!.toggleCard();
-                  },
-                ),
+    return Visibility(
+      visible: _backOfCardVisible,
+      child: ListView(
+        shrinkWrap: true,
+        children: [
+          Form(
+            key: _beneficiaryAddressKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: InputField(
+              onChanged: (value) {
+                setState(() {});
+              },
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[0-9a-z]')),
               ],
+              controller: _beneficiaryAddressController,
+              hintText: 'Beneficiary address',
+              contentLeftPadding: 20.0,
+              validator: (value) => InputValidators.checkAddress(value),
             ),
-          ],
-        ),
-      ],
+          ),
+          StepperUtils.getBalanceWidget(widget.token, accountInfo!),
+          Form(
+            key: _mintAmountKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: InputField(
+              onChanged: (value) {
+                setState(() {});
+              },
+              inputFormatters: FormatUtils.getAmountTextInputFormatters(
+                _mintAmountController.text,
+              ),
+              controller: _mintAmountController,
+              validator: (value) => InputValidators.correctValue(
+                  value, _mintMaxAmount, widget.token.decimals, BigInt.zero),
+              suffixIcon: _getAmountSuffix(),
+              suffixIconConstraints: const BoxConstraints(maxWidth: 50.0),
+              hintText: 'Amount',
+              contentLeftPadding: 20.0,
+            ),
+          ),
+          kVerticalSpacing,
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Column(
+                children: [
+                  _getMintButtonViewModel(),
+                  const SizedBox(
+                    height: 10.0,
+                  ),
+                  StepperButton(
+                    text: 'Go back',
+                    onPressed: () {
+                      _cardKey.currentState!.toggleCard();
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 
@@ -588,7 +599,6 @@ class _TokenCardState extends State<TokenCard> {
         model.stream.listen((event) {
           setState(() {
             _beneficiaryAddressKey.currentState!.reset();
-            _beneficiaryAddressController.clear();
             _mintAmountKey.currentState!.reset();
             _mintAmountController.clear();
           });
@@ -608,7 +618,8 @@ class _TokenCardState extends State<TokenCard> {
     );
   }
 
-  Future<void> _sendMintSuccessfulNotification(AccountBlockTemplate event) async {
+  Future<void> _sendMintSuccessfulNotification(
+      AccountBlockTemplate event) async {
     await sl.get<NotificationsBloc>().addNotification(
           WalletNotification(
             title: 'Successfully minted ${event.amount.addDecimals(
@@ -627,21 +638,24 @@ class _TokenCardState extends State<TokenCard> {
   Widget _getMintButton(MintTokenBloc model) {
     return LoadingButton.stepper(
       text: 'Mint',
-      onPressed: _mintMaxAmount > BigInt.zero &&
-              _mintAmountController.text.isNotEmpty &&
-              InputValidators.correctValue(_mintAmountController.text,
-                      _mintMaxAmount, widget.token.decimals, BigInt.zero) ==
-                  null
-          ? () {
-              _mintButtonKey.currentState!.animateForward();
-              model.mintToken(
-                widget.token,
-                _mintAmountController.text
-                    .extractDecimals(widget.token.decimals),
-                Address.parse(_beneficiaryAddressController.text),
-              );
-            }
-          : null,
+      onPressed:
+          InputValidators.checkAddress(_beneficiaryAddressController.text) ==
+                      null &&
+                  _mintMaxAmount > BigInt.zero &&
+                  _mintAmountController.text.isNotEmpty &&
+                  InputValidators.correctValue(_mintAmountController.text,
+                          _mintMaxAmount, widget.token.decimals, BigInt.zero) ==
+                      null
+              ? () {
+                  _mintButtonKey.currentState!.animateForward();
+                  model.mintToken(
+                    widget.token,
+                    _mintAmountController.text
+                        .extractDecimals(widget.token.decimals),
+                    Address.parse(_beneficiaryAddressController.text),
+                  );
+                }
+              : null,
       key: _mintButtonKey,
     );
   }
@@ -654,47 +668,50 @@ class _TokenCardState extends State<TokenCard> {
   }
 
   Widget _getTransferOwnershipBackOfCard() {
-    return ListView(
-      shrinkWrap: true,
-      children: [
-        Form(
-          key: _newOwnerAddressKey,
-          autovalidateMode: AutovalidateMode.onUserInteraction,
-          child: InputField(
-            onChanged: (String value) {
-              setState(() {});
-            },
-            inputFormatters: [
-              FilteringTextInputFormatter.allow(RegExp(r'[0-9a-z]')),
-            ],
-            controller: _newOwnerAddressController,
-            hintText: 'New owner address',
-            contentLeftPadding: 20.0,
-            validator: (value) => InputValidators.checkAddress(value),
-          ),
-        ),
-        kVerticalSpacing,
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Column(
-              children: [
-                _getTransferOwnershipButtonViewModel(),
-                const SizedBox(
-                  height: 10.0,
-                ),
-                StepperButton(
-                  text: 'Go back',
-                  onPressed: () {
-                    _cardKey.currentState!.toggleCard();
-                  },
-                ),
+    return Visibility(
+      visible: _backOfCardVisible,
+      child: ListView(
+        shrinkWrap: true,
+        children: [
+          Form(
+            key: _newOwnerAddressKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: InputField(
+              onChanged: (String value) {
+                setState(() {});
+              },
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[0-9a-z]')),
               ],
+              controller: _newOwnerAddressController,
+              hintText: 'New owner address',
+              contentLeftPadding: 20.0,
+              validator: (value) => InputValidators.checkAddress(value),
             ),
-          ],
-        ),
-      ],
+          ),
+          kVerticalSpacing,
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Column(
+                children: [
+                  _getTransferOwnershipButtonViewModel(),
+                  const SizedBox(
+                    height: 10.0,
+                  ),
+                  StepperButton(
+                    text: 'Go back',
+                    onPressed: () {
+                      _cardKey.currentState!.toggleCard();
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/widgets/reusable_widgets/stepper_utils.dart
+++ b/lib/widgets/reusable_widgets/stepper_utils.dart
@@ -68,12 +68,15 @@ class StepperUtils {
   static Widget getBalanceWidget(Token token, AccountInfo accountInfo) {
     return Row(
       children: [
-        Padding(
-          padding: const EdgeInsets.only(left: 20.0, top: 10.0, bottom: 10.0),
-          child: AvailableBalance(
-            token,
-            accountInfo,
-          ),
+        Expanded(
+          child:
+            Padding(
+              padding: const EdgeInsets.only(left: 20.0, top: 10.0, bottom: 10.0),
+              child: AvailableBalance(
+                token,
+                accountInfo,
+              ),
+            ),
         ),
       ],
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -510,6 +510,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_flip_card:
+    dependency: "direct main"
+    description:
+      name: flutter_flip_card
+      sha256: "1de81921a3bcc40f2eae77db18bddc0ce6bbea6be30274ffa83e8c06fe2b1936"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.5"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   expandable: ^5.0.1
   marquee_widget: ^1.2.0
   layout: ^1.0.2
-  flutter_staggered_grid_view: ^0.4.0
+  flutter_staggered_grid_view: ^0.4.1
   flip_card: ^0.7.0
   auto_size_text: ^3.0.0
   window_manager: ^0.3.5
@@ -31,7 +31,7 @@ dependencies:
   intl: ^0.18.0
   package_info_plus: ^4.1.0
   device_info_plus: ^9.0.3
-  infinite_scroll_pagination: ^3.1.0
+  infinite_scroll_pagination: ^3.2.0
   share_plus: ^7.1.0
   page_transition: ^2.0.4
   file_selector: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   layout: ^1.0.2
   flutter_staggered_grid_view: ^0.4.1
   flip_card: ^0.7.0
+  flutter_flip_card: ^0.0.5
   auto_size_text: ^3.0.0
   window_manager: ^0.3.5
   stacked: ^3.4.1


### PR DESCRIPTION
This PR fixes issue #108 

The [flip_card](https://pub.dev/packages/flip_card) package has a known bug that causes "shadows" of some widgets to be visible from the back side of the card.

See https://github.com/BrunoJurkovic/flip_card/issues/86 for more information.

**Changes**
- The `flutter_flip_card` package is used for the token cards. 

**Additional changes**
- Validate BeneficiaryAddress when minting
- Do not clear BeneficiaryAddress after minting
- Expand available balance to prevent clipping
- Update `flutter_staggered_grid_view` from `v0.4.0` to `v0.4.1`
- Update `infinite_scroll_pagination` from `v3.1.0` to `v3.2.0`

**Additional information**
The `flip_card` package is still used for the `CardScaffold` class. The `flutter_flip_card` package is only used to circumvent the token card bug.
There is a slight difference how both packages flip. The `flip_card` toggles and the `flutter_flip_card` flips.