### PR TITLE
Apply sync check to all hosts

### DIFF
--- a/lib/utils/account_block_utils.dart
+++ b/lib/utils/account_block_utils.dart
@@ -39,12 +39,10 @@ class AccountBlockUtils {
     bool waitForRequiredPlasma = false,
   }) async {
     SyncInfo syncInfo = await zenon!.stats.syncInfo();
-    bool nodeIsSynced = kCurrentNode == kLocalhostDefaultNodeUrl
-        ? (syncInfo.state == SyncState.syncDone ||
-            (syncInfo.targetHeight > 0 &&
-                syncInfo.currentHeight > 0 &&
-                (syncInfo.targetHeight - syncInfo.currentHeight) < 20))
-        : true;
+    bool nodeIsSynced = (syncInfo.state == SyncState.syncDone ||
+        (syncInfo.targetHeight > 0 &&
+            syncInfo.currentHeight > 0 &&
+            (syncInfo.targetHeight - syncInfo.currentHeight) < 20));
     if (nodeIsSynced) {
       // Acquire wallet lock to prevent concurrent access.
       final wallet = await kWalletFile!.open();


### PR DESCRIPTION
This PR applies the sync check to all hosts and not just only the localhost.

Before sending an account block a check is made whether the connected node is synced. This check is only applied when connected to a localhost node and assumes remote hosts are always synced. This PR removes this assumption and applies the sync check to all nodes.