### PR TITLE
Retry Web3WalletService init on SocketException

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
@@ -86,7 +87,7 @@ main() async {
 
   retry(
     () => web3WalletService!.init(),
-    retryIf: (e) => e is SocketException,
+    retryIf: (e) => e is SocketException || e is TimeoutException,
     maxAttempts: 0x7FFFFFFFFFFFFFFF
   );
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:logging/logging.dart';
 import 'package:overlay_support/overlay_support.dart';
 import 'package:path/path.dart' as path;
 import 'package:provider/provider.dart';
+import 'package:retry/retry.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/auto_unlock_htlc_worker.dart';
@@ -36,10 +37,10 @@ import 'package:znn_sdk_dart/znn_sdk_dart.dart';
 Zenon? zenon;
 SharedPrefsService? sharedPrefsService;
 HtlcSwapsService? htlcSwapsService;
+IWeb3WalletService? web3WalletService;
 
 final sl = GetIt.instance;
 
-IWeb3WalletService? web3WalletService;
 final globalNavigatorKey = GlobalKey<NavigatorState>();
 
 main() async {
@@ -83,7 +84,11 @@ main() async {
   // Setup services
   setup();
 
-  await web3WalletService!.init();
+  retry(
+    () => web3WalletService!.init(),
+    retryIf: (e) => e is SocketException,
+    maxAttempts: 0x7FFFFFFFFFFFFFFF
+  );
 
   // Setup local_notifier
   await localNotifier.setup(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1059,6 +1059,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  retry:
+    dependency: "direct main"
+    description:
+      name: retry
+      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   rxdart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,8 @@ dependencies:
   ai_barcode_scanner: ^3.4.3
   version: ^3.0.0
   mutex: ^3.1.0
+  retry: ^3.1.2
+
 dev_dependencies:
   build_runner: ^2.4.6
   hive_generator: ^2.0.0


### PR DESCRIPTION
This PR fixes issue #118 

**Problem**
The `Web3WalletService` throws a `SocketException` when initializing without a valid internet connection. The unhandled exception prevents Syrius from continuing.

**Error:**
- `Unhandled Exception: SocketException: Failed host lookup: '[relay.walletconnect.com](http://relay.walletconnect.com/)' (OS Error: Host is unknown)`

**Solution**
The initialization of the `Web3WalletService` must retry until successful and allow Syrius to start normally.