### PR TITLE
Update znn_ledger_dart dependency

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -807,10 +807,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1604,11 +1604,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "release/v0.0.4"
-      resolved-ref: "9fde67444e82448a2f5dc1d9f0ee32ef8cdd9600"
-      url: "https://github.com/hypercore-one/znn_ledger_dart.git"
+      ref: main
+      resolved-ref: "56d7e8912ee69eed6895a4afffebca2ed1b965c4"
+      url: "https://github.com/zenon-network/znn_ledger_dart.git"
     source: git
-    version: "0.0.4"
+    version: "0.0.5"
   znn_sdk_dart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,8 +48,8 @@ dependencies:
       ref: 8511f17a0dfa721e8f0ec2e0b0aae409f509e102
   znn_ledger_dart:
     git:
-      url: https://github.com/hypercore-one/znn_ledger_dart.git
-      ref: release/v0.0.4
+      url: https://github.com/zenon-network/znn_ledger_dart.git
+      ref: main
   json_rpc_2: ^3.0.2
   path: ^1.8.2
   ffi: ^2.1.0


### PR DESCRIPTION
This PR updates the `znn_ledger_dart` dependency to use the latest version from zenon-network.