### PR TITLE
Update znn dependencies

### DIFF
--- a/.github/workflows/syrius_builder.yml
+++ b/.github/workflows/syrius_builder.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout zenon-node-database repository
         uses: actions/checkout@v4
         with:
-          repository: HyperCore-One/zenon-node-database
+          repository: zenon-network/zenon-node-database
           path: ./node-db
           ref: main
       - name: Copy community nodes
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout zenon-node-database repository
         uses: actions/checkout@v4
         with:
-          repository: HyperCore-One/zenon-node-database
+          repository: zenon-network/zenon-node-database
           path: ./node-db
           ref: main
       - name: Copy community nodes
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout zenon-node-database repository
         uses: actions/checkout@v4
         with:
-          repository: HyperCore-One/zenon-node-database
+          repository: zenon-network/zenon-node-database
           path: ./node-db
           ref: main
       - name: Copy community nodes

--- a/lib/widgets/reusable_widgets/dropdown/basic_dropdown.dart
+++ b/lib/widgets/reusable_widgets/dropdown/basic_dropdown.dart
@@ -48,7 +48,7 @@ class BasicDropdown<T> extends StatelessWidget {
                 value: item,
                 child: Text(
                   item.label,
-                  style: Theme.of(context).textTheme.bodyText2!.copyWith(
+                  style: Theme.of(context).textTheme.bodyMedium!.copyWith(
                         color: _selectedValue == item
                             ? onChangedCallback != null
                                 ? AppColors.znnColor

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -807,10 +807,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -1604,8 +1604,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: main
-      resolved-ref: "56d7e8912ee69eed6895a4afffebca2ed1b965c4"
+      ref: "v0.0.5"
+      resolved-ref: "9c6b251f4be5ab05447f17f63acd56f7a9ff040b"
       url: "https://github.com/zenon-network/znn_ledger_dart.git"
     source: git
     version: "0.0.5"
@@ -1613,7 +1613,7 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "8511f17a0dfa721e8f0ec2e0b0aae409f509e102"
+      ref: "v0.0.7"
       resolved-ref: "8511f17a0dfa721e8f0ec2e0b0aae409f509e102"
       url: "https://github.com/zenon-network/znn_sdk_dart.git"
     source: git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,11 +45,11 @@ dependencies:
   znn_sdk_dart:
     git:
       url: https://github.com/zenon-network/znn_sdk_dart.git
-      ref: 8511f17a0dfa721e8f0ec2e0b0aae409f509e102
+      ref: v0.0.7
   znn_ledger_dart:
     git:
       url: https://github.com/zenon-network/znn_ledger_dart.git
-      ref: main
+      ref: v0.0.5
   json_rpc_2: ^3.0.2
   path: ^1.8.2
   ffi: ^2.1.0


### PR DESCRIPTION
This PR updates the hc1 `zenon-node-database` workflow references to zenon-network and references the znn dependencies by tag.

**Additional changes**
- Update deprecated TextStyle property `bodyText2`