### PR TITLE
Update macOS environment

### DIFF
--- a/.github/workflows/syrius_builder.yml
+++ b/.github/workflows/syrius_builder.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-macos:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the build-macos step of the build and release workflow to environment `macOS-14`.