### PR TITLE
Update Flutter to v3.27.1

### DIFF
--- a/.github/workflows/syrius_builder.yml
+++ b/.github/workflows/syrius_builder.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  FLUTTER_VERSION: "3.24.3"
+  FLUTTER_VERSION: "3.27.1"
 
 jobs:
   build-macos:


### PR DESCRIPTION
This PR updates Flutter of the build and release workflow to v3.27.1.