### PR TITLE
Fix building desktop apps

### DIFF
--- a/.github/workflows/syrius_builder.yml
+++ b/.github/workflows/syrius_builder.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  FLUTTER_VERSION: "3.38.9"
+  FLUTTER_VERSION: "3.44.0"
 
 jobs:
   build-macos:

--- a/.github/workflows/syrius_builder.yml
+++ b/.github/workflows/syrius_builder.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-macos:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -140,53 +140,25 @@ endif()
 # Bundle required ZNN libraries for Syrius
 set(SYRIUS_PROJECT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/..")
 
-# Read lines from the file `package_config_subset` that match the regex pattern
-# looking for paths containing "znn_sdk_dart" and ending with a "/".
-file(STRINGS "${SYRIUS_PROJECT_DIRECTORY}/.dart_tool/package_config_subset"
-        ZNN_SDK_DART_PATHS REGEX "(file:).*(znn_sdk_dart).*/$" )
+function(GET_PACKAGE_ROOT_URI PACKAGE_NAME OUTPUT_VARIABLE)
+  file(READ "${SYRIUS_PROJECT_DIRECTORY}/.dart_tool/package_config.json" PACKAGE_CONFIG_JSON)
+  string(REGEX MATCH
+    "\\{[^{}]*\"name\"[ \\r\\n\\t]*:[ \\r\\n\\t]*\"${PACKAGE_NAME}\"[^{}]*\"rootUri\"[ \\r\\n\\t]*:[ \\r\\n\\t]*\"([^\"]+)\"[^{}]*\\}"
+    PACKAGE_CONFIG_ENTRY
+    "${PACKAGE_CONFIG_JSON}")
 
-# Initialize an empty variable to store the final znn_sdk_dart path
-set(ZNN_SDK_DART_PATH "")
-
-# Loop through each path found by the file command
-foreach(PATH ${ZNN_SDK_DART_PATHS})
-  # Exclude paths containing "/lib/" using a conditional check
-  if(NOT "${PATH}" MATCHES ".*/lib/.*")
-    # If the condition is met, set the current path as ZNN_SDK_DART_PATH
-    set(ZNN_SDK_DART_PATH ${PATH})
+  if(NOT PACKAGE_CONFIG_ENTRY)
+    message(FATAL_ERROR "Unable to find ${PACKAGE_NAME} in .dart_tool/package_config.json. Run `flutter pub get` and try again.")
   endif()
-endforeach()
 
-# Remove the "file://" prefix from the selected path, if present
-string(REPLACE "file://" "" ZNN_SDK_DART_PATH "${ZNN_SDK_DART_PATH}")
+  set(PACKAGE_ROOT_URI "${CMAKE_MATCH_1}")
+  string(REPLACE "file://" "" PACKAGE_ROOT_URI "${PACKAGE_ROOT_URI}")
+  string(STRIP "${PACKAGE_ROOT_URI}" PACKAGE_ROOT_URI)
+  set(${OUTPUT_VARIABLE} "${PACKAGE_ROOT_URI}" PARENT_SCOPE)
+endfunction()
 
-# Strip any leading or trailing whitespace from the cleaned path
-string(STRIP "${ZNN_SDK_DART_PATH}" ZNN_SDK_DART_PATH)
-
-# Repeat the same process for "znn_ledger_dart" paths:
-
-# Read lines from the file `package_config_subset` that match the regex pattern
-# looking for paths containing "znn_ledger_dart" and ending with a "/".
-file(STRINGS "${SYRIUS_PROJECT_DIRECTORY}/.dart_tool/package_config_subset"
-        ZNN_LEDGER_DART_PATHS REGEX "(file:).*(znn_ledger_dart).*/$" )
-
-# Initialize an empty variable to store the final znn_ledger_dart path
-set(ZNN_LEDGER_DART_PATH "")
-
-# Loop through each path found by the file command
-foreach(PATH ${ZNN_LEDGER_DART_PATHS})
-  # Exclude paths containing "/lib/" using a conditional check
-  if(NOT "${PATH}" MATCHES ".*/lib/.*")
-    # If the condition is met, set the current path as ZNN_LEDGER_DART_PATH
-    set(ZNN_LEDGER_DART_PATH ${PATH})
-  endif()
-endforeach()
-
-# Remove the "file://" prefix from the selected path, if present
-string(REPLACE "file://" "" ZNN_LEDGER_DART_PATH "${ZNN_LEDGER_DART_PATH}")
-
-# Strip any leading or trailing whitespace from the cleaned path
-string(STRIP "${ZNN_LEDGER_DART_PATH}" ZNN_LEDGER_DART_PATH)
+get_package_root_uri("znn_sdk_dart" ZNN_SDK_DART_PATH)
+get_package_root_uri("znn_ledger_dart" ZNN_LEDGER_DART_PATH)
 
 # Append the paths to various library files into the `SYRIUS_LIBRARIES` list.
 # These paths include:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,7 +88,7 @@ dependency_overrides:
   znn_sdk_dart:
     git:
       url: https://github.com/maznnwell/znn_sdk_dart.git
-      ref: refactor
+      ref: 16bf294b3e347cb4f9c1f47a7da5d60034724f95
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -111,53 +111,26 @@ install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
 # Bundle required ZNN libraries for Syrius
 set(SYRIUS_PROJECT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/..")
 
-# Read lines from the file `package_config_subset` that match the regex pattern
-# looking for paths containing "znn_sdk_dart" and ending with a "/".
-file(STRINGS "${SYRIUS_PROJECT_DIRECTORY}/.dart_tool/package_config_subset"
-        ZNN_SDK_DART_PATHS REGEX "(file:).*(znn_sdk_dart).*/$" )
+function(GET_PACKAGE_ROOT_URI PACKAGE_NAME OUTPUT_VARIABLE)
+  file(READ "${SYRIUS_PROJECT_DIRECTORY}/.dart_tool/package_config.json" PACKAGE_CONFIG_JSON)
+  string(REGEX MATCH
+    "\\{[^{}]*\"name\"[ \\r\\n\\t]*:[ \\r\\n\\t]*\"${PACKAGE_NAME}\"[^{}]*\"rootUri\"[ \\r\\n\\t]*:[ \\r\\n\\t]*\"([^\"]+)\"[^{}]*\\}"
+    PACKAGE_CONFIG_ENTRY
+    "${PACKAGE_CONFIG_JSON}")
 
-# Initialize an empty variable to store the final znn_sdk_dart path
-set(ZNN_SDK_DART_PATH "")
-
-# Loop through each path found by the file command
-foreach(PATH ${ZNN_SDK_DART_PATHS})
-  # Exclude paths containing "/lib/" using a conditional check
-  if(NOT "${PATH}" MATCHES ".*/lib/.*")
-    # If the condition is met, set the current path as ZNN_SDK_DART_PATH
-    set(ZNN_SDK_DART_PATH ${PATH})
+  if(NOT PACKAGE_CONFIG_ENTRY)
+    message(FATAL_ERROR "Unable to find ${PACKAGE_NAME} in .dart_tool/package_config.json. Run `flutter pub get` and try again.")
   endif()
-endforeach()
 
-# Remove the "file:///" prefix from the selected path, if present
-string(REPLACE "file:///" "" ZNN_SDK_DART_PATH "${ZNN_SDK_DART_PATH}")
+  set(PACKAGE_ROOT_URI "${CMAKE_MATCH_1}")
+  string(REPLACE "file:///" "" PACKAGE_ROOT_URI "${PACKAGE_ROOT_URI}")
+  string(REPLACE "file://" "" PACKAGE_ROOT_URI "${PACKAGE_ROOT_URI}")
+  string(STRIP "${PACKAGE_ROOT_URI}" PACKAGE_ROOT_URI)
+  set(${OUTPUT_VARIABLE} "${PACKAGE_ROOT_URI}" PARENT_SCOPE)
+endfunction()
 
-# Strip any leading or trailing whitespace from the cleaned path
-string(STRIP "${ZNN_SDK_DART_PATH}" ZNN_SDK_DART_PATH)
-
-# Repeat the same process for "znn_ledger_dart" paths:
-
-# Read lines from the file `package_config_subset` that match the regex pattern
-# looking for paths containing "znn_ledger_dart" and ending with a "/".
-file(STRINGS "${SYRIUS_PROJECT_DIRECTORY}/.dart_tool/package_config_subset"
-        ZNN_LEDGER_DART_PATHS REGEX "(file:).*(znn_ledger_dart).*/$" )
-
-# Initialize an empty variable to store the final znn_ledger_dart path
-set(ZNN_LEDGER_DART_PATH "")
-
-# Loop through each path found by the file command
-foreach(PATH ${ZNN_LEDGER_DART_PATHS})
-  # Exclude paths containing "/lib/" using a conditional check
-  if(NOT "${PATH}" MATCHES ".*/lib/.*")
-    # If the condition is met, set the current path as ZNN_LEDGER_DART_PATH
-    set(ZNN_LEDGER_DART_PATH ${PATH})
-  endif()
-endforeach()
-
-# Remove the "file:///" prefix from the selected path, if present
-string(REPLACE "file:///" "" ZNN_LEDGER_DART_PATH "${ZNN_LEDGER_DART_PATH}")
-
-# Strip any leading or trailing whitespace from the cleaned path
-string(STRIP "${ZNN_LEDGER_DART_PATH}" ZNN_LEDGER_DART_PATH)
+get_package_root_uri("znn_sdk_dart" ZNN_SDK_DART_PATH)
+get_package_root_uri("znn_ledger_dart" ZNN_LEDGER_DART_PATH)
 
 # Append the paths to various library files into the `SYRIUS_LIBRARIES` list.
 # These paths include:


### PR DESCRIPTION
After merging the code from the previous PR, I saw that the GIthubActions workflow that builds the apps fails: https://github.com/zenon-network/syrius/actions/runs/28186723152

This PR fixes the issue and upgrades to the latest version Flutter and the macOS build runner.

It also pins the Dart Zenon SDK to a specific commit; the reason being is that the refactor branch contains changes for which the wallet, as it is in this PR, is not adapted to.